### PR TITLE
Fix planner math variable substitution and session set counting

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/planner/HistoryAnalyzer.kt
+++ b/app/src/main/java/com/chrislentner/coach/planner/HistoryAnalyzer.kt
@@ -96,7 +96,7 @@ class HistoryAnalyzer(private val config: CoachConfig) {
 
         if (matchingLogs.isEmpty()) return false
 
-        val prescribedSets = block.prescription.sumOf { it.sets ?: 0 }
+        val prescribedSets = block.prescription.sumOf { it.sets ?: 1 }
 
         if (prescribedSets > 0) {
             val actualSets = matchingLogs.count { !it.skipped }

--- a/app/src/main/java/com/chrislentner/coach/planner/MathEvaluator.kt
+++ b/app/src/main/java/com/chrislentner/coach/planner/MathEvaluator.kt
@@ -5,7 +5,8 @@ object MathEvaluator {
 
     fun evaluate(expression: String, variables: Map<String, Double>): Double {
         var expr = expression
-        for ((key, value) in variables) {
+        val sortedVariables = variables.entries.sortedByDescending { it.key.length }
+        for ((key, value) in sortedVariables) {
             expr = expr.replace(key, value.toString())
         }
         // Remove whitespace


### PR DESCRIPTION
### Motivation
- Fatigue formulas can include variables with overlapping names (e.g. `performed_minutes` and `$performed_minutes`) and naive replacement can produce partial substitutions that break evaluation. 
- Blocks that omit `sets` should be treated as single-set prescriptions when assessing whether a past session satisfied the block for progression decisions. 

### Description
- In `MathEvaluator.evaluate` sort replacement variables by descending key length and substitute in that order to avoid partial/shorter-key matches. 
- In `HistoryAnalyzer.isBlockSatisfied` treat missing `Prescription.sets` as `1` by changing the fold to `it.sets ?: 1` so unspecified counts are considered single sets. 

### Testing
- No automated tests were executed as part of this change (existing unit tests are present in the project but were not run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970267a5b2083329c550641850447f6)