### PR TITLE
Add "Suggest Schedule" 7-day planner UI and planner helpers

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
@@ -1,6 +1,7 @@
 package com.chrislentner.coach.ui
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
@@ -40,6 +41,25 @@ fun CoachApp(
                 factory = PastWorkoutsViewModelFactory(workoutRepository)
             )
             PastWorkoutsScreen(navController = navController, viewModel = viewModel)
+        }
+        composable("suggested_schedule") {
+            val viewModel: SuggestedScheduleViewModel = viewModel(
+                factory = SuggestedScheduleViewModelFactory(workoutRepository, repository, planner)
+            )
+            SuggestedScheduleScreen(navController = navController, viewModel = viewModel)
+        }
+        composable("suggested_schedule_detail/{dayIndex}") { backStackEntry ->
+            val dayIndex = backStackEntry.arguments?.getString("dayIndex")?.toIntOrNull() ?: 0
+            val parentEntry = remember { navController.getBackStackEntry("suggested_schedule") }
+            val viewModel: SuggestedScheduleViewModel = viewModel(
+                parentEntry,
+                factory = SuggestedScheduleViewModelFactory(workoutRepository, repository, planner)
+            )
+            SuggestedScheduleDetailScreen(
+                navController = navController,
+                viewModel = viewModel,
+                dayIndex = dayIndex
+            )
         }
         composable("workout_detail/{sessionId}") { backStackEntry ->
             val sessionIdStr = backStackEntry.arguments?.getString("sessionId")

--- a/app/src/main/java/com/chrislentner/coach/ui/HomeScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/HomeScreen.kt
@@ -62,6 +62,12 @@ fun HomeScreen(
             Button(onClick = { navController.navigate("past_workouts") }) {
                 Text("Past Workouts")
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(onClick = { navController.navigate("suggested_schedule") }) {
+                Text("Suggest Schedule")
+            }
         }
     }
 }

--- a/app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleScreen.kt
@@ -1,0 +1,155 @@
+package com.chrislentner.coach.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.Button
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuggestedScheduleScreen(
+    navController: NavController,
+    viewModel: SuggestedScheduleViewModel
+) {
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Suggested Schedule") },
+                navigationIcon = {
+                    Button(onClick = { navController.popBackStack() }) {
+                        Text("Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        when {
+            viewModel.isLoading -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("Building your 7-day plan...", style = MaterialTheme.typography.bodyLarge)
+                }
+            }
+            viewModel.errorMessage != null -> {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text(viewModel.errorMessage ?: "Unable to build plan.")
+                }
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(innerPadding)
+                ) {
+                    item {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(16.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text("Date", fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                            Text("Location", fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                            Text("Sets", fontWeight = FontWeight.Bold, modifier = Modifier.weight(0.5f))
+                        }
+                        HorizontalDivider()
+                    }
+
+                    itemsIndexed(viewModel.dayPlans) { index, plan ->
+                        SessionRow(
+                            session = plan.summary,
+                            formattedDate = viewModel.formatDate(plan.summary.date),
+                            onClick = { navController.navigate("suggested_schedule_detail/$index") }
+                        )
+                        HorizontalDivider()
+                    }
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SuggestedScheduleDetailScreen(
+    navController: NavController,
+    viewModel: SuggestedScheduleViewModel,
+    dayIndex: Int
+) {
+    val plan = viewModel.getPlanForDay(dayIndex)
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Suggested Sets") },
+                navigationIcon = {
+                    Button(onClick = { navController.popBackStack() }) {
+                        Text("Back")
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        if (plan == null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding),
+                contentAlignment = Alignment.Center
+            ) {
+                Text("Plan not found.")
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+            ) {
+                item {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(16.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Text("Exercise", fontWeight = FontWeight.Bold, modifier = Modifier.weight(2f))
+                        Text("Load", fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                        Text("Target", fontWeight = FontWeight.Bold, modifier = Modifier.weight(1f))
+                    }
+                    HorizontalDivider()
+                }
+
+                itemsIndexed(plan.logs) { _, log ->
+                    LogEntryRow(log = log, onClick = {})
+                    HorizontalDivider()
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleViewModel.kt
@@ -1,0 +1,194 @@
+package com.chrislentner.coach.ui
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.chrislentner.coach.database.ScheduleEntry
+import com.chrislentner.coach.database.ScheduleRepository
+import com.chrislentner.coach.database.SessionSummary
+import com.chrislentner.coach.database.WorkoutLogEntry
+import com.chrislentner.coach.database.WorkoutRepository
+import com.chrislentner.coach.planner.AdvancedWorkoutPlanner
+import kotlinx.coroutines.launch
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+import java.util.concurrent.TimeUnit
+
+class SuggestedScheduleViewModel(
+    private val workoutRepository: WorkoutRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val planner: AdvancedWorkoutPlanner?
+) : ViewModel() {
+
+    var dayPlans by mutableStateOf<List<SuggestedDayPlan>>(emptyList())
+        private set
+
+    var isLoading by mutableStateOf(true)
+        private set
+
+    var errorMessage by mutableStateOf<String?>(null)
+        private set
+
+    init {
+        buildSuggestedPlan()
+    }
+
+    fun formatDate(dateStr: String): String {
+        return try {
+            val parser = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+            val date = parser.parse(dateStr) ?: return dateStr
+            val cal = Calendar.getInstance()
+            cal.time = date
+            val year = cal.get(Calendar.YEAR)
+
+            val now = Calendar.getInstance()
+            val currentYear = now.get(Calendar.YEAR)
+
+            val pattern = if (year == currentYear) "MMM d" else "MMM d, yyyy"
+            SimpleDateFormat(pattern, Locale.US).format(date)
+        } catch (e: Exception) {
+            dateStr
+        }
+    }
+
+    fun getPlanForDay(index: Int): SuggestedDayPlan? {
+        return dayPlans.getOrNull(index)
+    }
+
+    private fun buildSuggestedPlan() {
+        viewModelScope.launch {
+            if (planner == null) {
+                errorMessage = "Planner unavailable."
+                isLoading = false
+                return@launch
+            }
+
+            val now = Date()
+            val historyWindowDays = planner.getHistoryWindowDays()
+            val historyStart = now.time - TimeUnit.DAYS.toMillis(historyWindowDays.toLong())
+            val history = workoutRepository.getHistorySince(historyStart).toMutableList()
+            val fallbackSchedule = scheduleRepository.getLastSchedule()
+            val priorityTargets = planner.getTargetPriorityOrder()
+
+            val plans = mutableListOf<SuggestedDayPlan>()
+
+            for (dayOffset in 0 until 7) {
+                val dayDate = getStartOfDay(now, dayOffset)
+                val dateStr = formatDateKey(dayDate)
+                val baseSchedule = scheduleRepository.getScheduleByDate(dateStr)
+                    ?: fallbackSchedule
+                    ?: defaultSchedule(dateStr, dayDate)
+
+                val scheduleForDay = baseSchedule.copy(
+                    date = dateStr,
+                    timeInMillis = alignTime(baseSchedule.timeInMillis, dayDate)
+                )
+
+                val homeSchedule = scheduleForDay.copy(location = "Home")
+                val gymSchedule = scheduleForDay.copy(location = "Gym")
+
+                val homePlan = planner.generatePlanResult(dayDate, history, homeSchedule)
+                val gymPlan = planner.generatePlanResult(dayDate, history, gymSchedule)
+
+                val chosenPlan = choosePlan(homePlan, gymPlan, priorityTargets)
+                val chosenSchedule = if (chosenPlan === homePlan) homeSchedule else gymSchedule
+
+                history.addAll(chosenPlan.dummyLogs)
+
+                val summary = SessionSummary(
+                    id = dayOffset.toLong(),
+                    date = dateStr,
+                    location = chosenSchedule.location,
+                    setCount = chosenPlan.steps.size
+                )
+                plans.add(SuggestedDayPlan(summary, chosenPlan.dummyLogs))
+            }
+
+            dayPlans = plans
+            isLoading = false
+        }
+    }
+
+    private fun choosePlan(
+        homePlan: AdvancedWorkoutPlanner.PlanResult,
+        gymPlan: AdvancedWorkoutPlanner.PlanResult,
+        priorityTargets: List<String>
+    ): AdvancedWorkoutPlanner.PlanResult {
+        priorityTargets.forEach { target ->
+            val homeDeficit = homePlan.deficits[target] ?: 0.0
+            val gymDeficit = gymPlan.deficits[target] ?: 0.0
+            if (homeDeficit < gymDeficit) return homePlan
+            if (gymDeficit < homeDeficit) return gymPlan
+        }
+        return homePlan
+    }
+
+    private fun defaultSchedule(dateStr: String, date: Date): ScheduleEntry {
+        val calendar = Calendar.getInstance()
+        calendar.time = date
+        calendar.set(Calendar.HOUR_OF_DAY, 7)
+        calendar.set(Calendar.MINUTE, 0)
+        calendar.set(Calendar.SECOND, 0)
+        calendar.set(Calendar.MILLISECOND, 0)
+        return ScheduleEntry(
+            date = dateStr,
+            timeInMillis = calendar.timeInMillis,
+            durationMinutes = 45,
+            location = "Home"
+        )
+    }
+
+    private fun getStartOfDay(date: Date, offsetDays: Int): Date {
+        val cal = Calendar.getInstance()
+        cal.time = date
+        cal.add(Calendar.DAY_OF_YEAR, offsetDays)
+        cal.set(Calendar.HOUR_OF_DAY, 0)
+        cal.set(Calendar.MINUTE, 0)
+        cal.set(Calendar.SECOND, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        return Date(cal.timeInMillis)
+    }
+
+    private fun formatDateKey(date: Date): String {
+        val formatter = SimpleDateFormat("yyyy-MM-dd", Locale.US)
+        formatter.timeZone = TimeZone.getTimeZone("UTC")
+        return formatter.format(date)
+    }
+
+    private fun alignTime(baseTimeMillis: Long, date: Date): Long {
+        val baseCal = Calendar.getInstance()
+        baseCal.timeInMillis = baseTimeMillis
+        val targetCal = Calendar.getInstance()
+        targetCal.time = date
+        targetCal.set(Calendar.HOUR_OF_DAY, baseCal.get(Calendar.HOUR_OF_DAY))
+        targetCal.set(Calendar.MINUTE, baseCal.get(Calendar.MINUTE))
+        targetCal.set(Calendar.SECOND, 0)
+        targetCal.set(Calendar.MILLISECOND, 0)
+        return targetCal.timeInMillis
+    }
+}
+
+data class SuggestedDayPlan(
+    val summary: SessionSummary,
+    val logs: List<WorkoutLogEntry>
+)
+
+class SuggestedScheduleViewModelFactory(
+    private val workoutRepository: WorkoutRepository,
+    private val scheduleRepository: ScheduleRepository,
+    private val planner: AdvancedWorkoutPlanner?
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SuggestedScheduleViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return SuggestedScheduleViewModel(workoutRepository, scheduleRepository, planner) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a quick entry on the home screen to generate a suggested 7-day training plan when the user wants a recommended schedule. 
- Decide per-day `Home` vs `Gym` by comparing planner outputs to reduce deficits and chain chosen plans into in-memory history for subsequent days. 
- Reuse existing past-workouts UI components so the suggested schedule overview/detail match the app's session and set display. 

### Description
- Add a `Suggest Schedule` button to the home screen (`app/src/main/java/com/chrislentner/coach/ui/HomeScreen.kt`) and navigation routes in `CoachApp` (`app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt`).
- Implement a `SuggestedScheduleScreen` list and `SuggestedScheduleDetailScreen` detail UI that reuse `SessionRow` and `LogEntryRow` for the overview and set list (`app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleScreen.kt`).
- Add `SuggestedScheduleViewModel` and `SuggestedScheduleViewModelFactory` to build a 7-day plan in memory by fetching history, generating both `Home` and `Gym` plans, choosing the one that reduces deficits per target priority, and appending chosen plan dummy logs to the in-memory history (`app/src/main/java/com/chrislentner/coach/ui/SuggestedScheduleViewModel.kt`).
- Extend the planner with `PlanResult`, `generatePlanResult`, `getHistoryWindowDays`, and `getTargetPriorityOrder` helpers and refactor internal plan build to `buildPlan` to return deficits and dummy logs used by the view model (`app/src/main/java/com/chrislentner/coach/planner/AdvancedWorkoutPlanner.kt`).
- Align daily schedule times when constructing per-day `ScheduleEntry` instances and fall back to a default schedule if none exists in the DB.

### Testing
- No automated tests were executed on the modified code as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970202d728c8332992d652d3f1cbba7)