### PR TITLE
Fix typo in exercise name in coach.yaml

### DIFF
--- a/app/src/main/assets/coach.yaml
+++ b/app/src/main/assets/coach.yaml
@@ -194,7 +194,7 @@ priorities:
             sets: 1
             reps: 3
             seconds_per_rep: 10
-          - exercise: pike_lift_cracrk
+          - exercise: pike_lift_cracr
             sets: 3
             reps: 5
             tempo: "5050"


### PR DESCRIPTION
Renamed `pike_lift_cracrk` to `pike_lift_cracr` in `app/src/main/assets/coach.yaml`. This ensures the correct exercise name is used in the configuration.

---
*PR created automatically by Jules for task [6291581153114590087](https://jules.google.com/task/6291581153114590087) started by @clentner*