### PR TITLE
Remove outdated Calendar comment

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/ui/WeeklyPlannerViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/WeeklyPlannerViewModel.kt
@@ -52,7 +52,6 @@ class WeeklyPlannerViewModel(
 
             val newDays = mutableListOf<PlannerDayUiModel>()
 
-            // Reset calendar to today for the loop
             var loopDate = startLocalDate
 
             for (i in 0..6) {


### PR DESCRIPTION
Removed a comment in `WeeklyPlannerViewModel.kt` that incorrectly referred to a `LocalDate` variable as "calendar" and implied it was being "reset", which was a remnant of legacy `java.util.Calendar` usage. The codebase has been migrated to `java.time`, making this comment obsolete and misleading.

Verified that the app compiles and `WeeklyPlannerViewModelTest` passes.

---
*PR created automatically by Jules for task [10802500894652232052](https://jules.google.com/task/10802500894652232052) started by @clentner*