### PR TITLE
Add Status & Deficits Screen

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/planner/AdvancedWorkoutPlanner.kt
+++ b/app/src/main/java/com/chrislentner/coach/planner/AdvancedWorkoutPlanner.kt
@@ -20,7 +20,7 @@ data class Plan(
 
 class AdvancedWorkoutPlanner(
     val config: CoachConfig,
-    private val historyAnalyzer: HistoryAnalyzer,
+    val historyAnalyzer: HistoryAnalyzer,
     private val progressionEngine: ProgressionEngine
 ) {
 

--- a/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
@@ -98,5 +98,15 @@ fun CoachApp(
                 androidx.compose.material3.Text("Planner configuration not found.")
             }
         }
+        composable("status") {
+            if (planner != null) {
+                val viewModel: StatusViewModel = viewModel(
+                    factory = StatusViewModelFactory(workoutRepository, planner)
+                )
+                StatusScreen(navController = navController, viewModel = viewModel)
+            } else {
+                androidx.compose.material3.Text("Planner configuration not found.")
+            }
+        }
     }
 }

--- a/app/src/main/java/com/chrislentner/coach/ui/HomeScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/HomeScreen.kt
@@ -74,6 +74,12 @@ fun HomeScreen(
 
             Spacer(modifier = Modifier.height(16.dp))
 
+            Button(onClick = { navController.navigate("status") }) {
+                Text("Current Status")
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             Button(onClick = { navController.navigate("workout") }) {
                 Text("Start Workout")
             }

--- a/app/src/main/java/com/chrislentner/coach/ui/StatusScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/StatusScreen.kt
@@ -1,0 +1,185 @@
+package com.chrislentner.coach.ui
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun StatusScreen(
+    navController: NavController,
+    viewModel: StatusViewModel
+) {
+    val state by viewModel.state.collectAsState()
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("Status & Deficits") },
+                navigationIcon = {
+                    IconButton(onClick = { navController.popBackStack() }) {
+                        Icon(
+                            imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                            contentDescription = "Back"
+                        )
+                    }
+                }
+            )
+        }
+    ) { innerPadding ->
+        if (state.isLoading) {
+            Box(modifier = Modifier.fillMaxSize().padding(innerPadding), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator()
+            }
+        } else {
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(16.dp),
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                item {
+                    Text(
+                        text = "Targets",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                items(state.targets) { target ->
+                    TargetItem(target)
+                }
+
+                item {
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text(
+                        text = "Fatigue Constraints",
+                        style = MaterialTheme.typography.titleLarge,
+                        color = MaterialTheme.colorScheme.primary
+                    )
+                }
+
+                items(state.fatigues) { fatigue ->
+                    FatigueItem(fatigue)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun TargetItem(target: TargetStatus) {
+    Card(
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        modifier = Modifier.fillMaxWidth()
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(
+                text = formatTargetName(target.id),
+                style = MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val progress = (target.performed / target.goal).coerceIn(0.0, 1.0).toFloat()
+            val label = if (target.type == "minutes") {
+                "${target.performed.toInt()} / ${target.goal.toInt()} mins"
+            } else {
+                "${target.performed.toInt()} / ${target.goal.toInt()} sets"
+            }
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                 Text(text = label, style = MaterialTheme.typography.bodyMedium)
+                 Text(
+                     text = "${target.windowDays} days",
+                     style = MaterialTheme.typography.bodySmall,
+                     color = MaterialTheme.colorScheme.onSurfaceVariant
+                 )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            LinearProgressIndicator(
+                progress = progress,
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            if (target.deficit > 0) {
+                Spacer(modifier = Modifier.height(4.dp))
+                Text(
+                    text = "Deficit: ${formatDeficit(target.deficit, target.type)}",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun FatigueItem(fatigue: FatigueStatus) {
+    Card(
+        elevation = CardDefaults.cardElevation(defaultElevation = 2.dp),
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(
+            containerColor = if (fatigue.isOk) MaterialTheme.colorScheme.surfaceContainer else MaterialTheme.colorScheme.errorContainer.copy(alpha=0.2f)
+        )
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
+                Text(
+                    text = fatigue.kind.replace("_", " ").capitalizeWords(),
+                    style = MaterialTheme.typography.titleMedium
+                )
+                Text(
+                    text = if (fatigue.isOk) "OK" else "Exceeded",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = if (fatigue.isOk) Color.Green else Color.Red
+                )
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(text = fatigue.reason, style = MaterialTheme.typography.bodySmall)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            val progress = (fatigue.currentLoad / fatigue.threshold).coerceIn(0.0, 1.0).toFloat()
+            LinearProgressIndicator(
+                progress = progress,
+                modifier = Modifier.fillMaxWidth(),
+                color = if (fatigue.isOk) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error
+            )
+            Spacer(modifier = Modifier.height(4.dp))
+            Text(
+                text = "Load: ${String.format("%.2f", fatigue.currentLoad)} / ${fatigue.threshold} (${fatigue.windowHours}h)",
+                style = MaterialTheme.typography.bodySmall
+            )
+        }
+    }
+}
+
+fun formatTargetName(id: String): String {
+    return id.replace("_", " ").capitalizeWords()
+}
+
+fun formatDeficit(deficit: Double, type: String): String {
+    return if (type == "minutes") {
+        "${deficit.toInt()} mins"
+    } else {
+        "${deficit.toInt()} sets"
+    }
+}
+
+fun String.capitalizeWords(): String = split(" ").joinToString(" ") { it.replaceFirstChar { char -> char.uppercase() } }

--- a/app/src/main/java/com/chrislentner/coach/ui/StatusViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/StatusViewModel.kt
@@ -1,0 +1,109 @@
+package com.chrislentner.coach.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.chrislentner.coach.database.WorkoutRepository
+import com.chrislentner.coach.planner.AdvancedWorkoutPlanner
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import java.time.Instant
+import kotlin.math.max
+
+data class TargetStatus(
+    val id: String,
+    val type: String, // "sets" or "minutes"
+    val goal: Double,
+    val performed: Double,
+    val deficit: Double,
+    val windowDays: Int
+)
+
+data class FatigueStatus(
+    val kind: String,
+    val currentLoad: Double,
+    val threshold: Double,
+    val windowHours: Int,
+    val isOk: Boolean,
+    val reason: String
+)
+
+data class StatusState(
+    val targets: List<TargetStatus> = emptyList(),
+    val fatigues: List<FatigueStatus> = emptyList(),
+    val isLoading: Boolean = true
+)
+
+class StatusViewModel(
+    private val repository: WorkoutRepository,
+    private val planner: AdvancedWorkoutPlanner
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(StatusState())
+    val state: StateFlow<StatusState> = _state
+
+    init {
+        loadStatus()
+    }
+
+    private fun loadStatus() {
+        viewModelScope.launch {
+            _state.value = _state.value.copy(isLoading = true)
+            // Calculate how much history we need.
+            // Max window for targets is usually 7 days, for fatigue 72 hours.
+            // Let's grab 14 days just to be safe and cover all windows.
+            val now = Instant.now()
+            val lookback = java.time.Duration.ofDays(14)
+            val cutoff = now.minus(lookback).toEpochMilli()
+
+            val history = repository.getHistorySince(cutoff)
+
+            val targets = planner.config.targets.map { target ->
+                val performed = planner.historyAnalyzer.getPerformed(target.id, target.windowDays, now, history)
+                val deficit = max(0.0, target.goal - performed)
+                TargetStatus(
+                    id = target.id,
+                    type = target.type,
+                    goal = target.goal.toDouble(),
+                    performed = performed,
+                    deficit = deficit,
+                    windowDays = target.windowDays
+                )
+            }
+
+            val fatigues = planner.config.fatigueConstraints.flatMap { (kind, constraints) ->
+                constraints.map { constraint ->
+                    val currentLoad = planner.historyAnalyzer.getAccumulatedFatigue(kind, constraint.windowHours, now, history)
+                    FatigueStatus(
+                        kind = kind,
+                        currentLoad = currentLoad,
+                        threshold = constraint.threshold,
+                        windowHours = constraint.windowHours,
+                        isOk = currentLoad < constraint.threshold,
+                        reason = constraint.reason
+                    )
+                }
+            }
+
+            _state.value = StatusState(
+                targets = targets,
+                fatigues = fatigues,
+                isLoading = false
+            )
+        }
+    }
+}
+
+class StatusViewModelFactory(
+    private val repository: WorkoutRepository,
+    private val planner: AdvancedWorkoutPlanner
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(StatusViewModel::class.java)) {
+            @Suppress("UNCHECKED_CAST")
+            return StatusViewModel(repository, planner) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}


### PR DESCRIPTION
Implemented a new "Status & Deficits" screen that allows users to view their current progress against configured workout targets and fatigue constraints.

Key changes:
- `HistoryAnalyzer`: Extracted logic for calculating performed work into a public `getPerformed` method.
- `AdvancedWorkoutPlanner`: Changed visibility of `historyAnalyzer` to public.
- `StatusViewModel`: Calculates `TargetStatus` and `FatigueStatus` based on workout history.
- `StatusScreen`: UI implementation using LazyColumn and LinearProgressIndicator.
- `HomeScreen`: Added navigation entry point.

---
*PR created automatically by Jules for task [11992220541435412659](https://jules.google.com/task/11992220541435412659) started by @clentner*