### PR TITLE
Refactor planner to use exercise-level contributions

### DIFF
--- a/app/src/main/assets/coach.yaml
+++ b/app/src/main/assets/coach.yaml
@@ -89,13 +89,13 @@ priorities:
         size_minutes: 30
         location: gym
         tags: [rehab, strength, patellar_tendon, knee_heavy, compound_heavy]
-        contributes_to:
-          - { target: patellar_hsr_squat_sets }
         prescription:
           - exercise: squat
             sets: 4
             reps: 8
             tempo: "3030"
+            contributes_to:
+              - { target: patellar_hsr_squat_sets }
             fatigue_loads:
               knee: 1.0
               cns: 1.0
@@ -110,13 +110,13 @@ priorities:
         size_minutes: 30
         location: gym
         tags: [rehab, strength, patellar_tendon, knee_heavy]
-        contributes_to:
-          - { target: patellar_hsr_sl_press_sets }
         prescription:
           - exercise: single_leg_press
             sets: 4
             reps: 9
             tempo: "3030"
+            contributes_to:
+              - { target: patellar_hsr_sl_press_sets }
             fatigue_loads:
               knee: 1.0
               cns: 0.5
@@ -131,12 +131,12 @@ priorities:
         size_minutes: 20
         location: gym
         tags: [rehab, cardio, patellar_tendon, zone2, knee_light]
-        contributes_to:
-          - { target: patellar_stairmaster_minutes }
-          - { target: zone2_minutes }
         prescription:
           - exercise: stairmaster
             target: Z2
+            contributes_to:
+              - { target: patellar_stairmaster_minutes }
+              - { target: zone2_minutes }
             fatigue_loads:
               knee: "$performed_minutes * 0.5 / 20"
               cns: "$performed_minutes * 0.25 / 30"
@@ -153,22 +153,22 @@ priorities:
         size_minutes: 8
         location: anywhere
         tags: [rehab, hip_abductor]
-        contributes_to:
-          - { target: hip_abductor_sets }
         prescription:
           - exercise: banded_x_walks
             sets: 2
+            contributes_to:
+              - { target: hip_abductor_sets }
 
       - block_name: banded_clamshells
         size_minutes: 8
         location: anywhere
         tags: [rehab, hip_abductor]
-        contributes_to:
-          - { target: hip_abductor_sets }
         prescription:
           - exercise: banded_clamshells
             sets: 2
             per_side: true
+            contributes_to:
+              - { target: hip_abductor_sets }
 
   mobility:
     blocks:
@@ -176,29 +176,37 @@ priorities:
         size_minutes: 45
         location: anywhere
         tags: [mobility]
-        contributes_to:
-          - { target: mobility_minutes }
         prescription:
           - exercise: foot_foam_roll
             seconds: 90
             per_side: true
+            contributes_to:
+              - { target: mobility_minutes }
           - exercise: calf_stretch
             sets: 3
             per_side: true
+            contributes_to:
+              - { target: mobility_minutes }
           - exercise: sciatic_floss
             sets: 3
             reps: 8
             tempo: "3030"
             per_side: true
+            contributes_to:
+              - { target: mobility_minutes }
           - exercise: pike_block_crush
             sets: 1
             reps: 3
             seconds_per_rep: 10
+            contributes_to:
+              - { target: mobility_minutes }
           - exercise: pike_lift_cracr
             sets: 3
             reps: 5
             tempo: "5050"
             per_side: true
+            contributes_to:
+              - { target: mobility_minutes }
 
   fcu_rehab:
     blocks:
@@ -206,27 +214,29 @@ priorities:
         size_minutes: 10
         location: anywhere
         tags: [rehab, forearm]
-        contributes_to:
-          - { target: fcu_rehab_sets }
         prescription:
           - exercise: wrist_flexion_iso
             sets: 5
             seconds: 30
+            contributes_to:
+              - { target: fcu_rehab_sets }
           - exercise: wrist_extension_iso
             sets: 5
             seconds: 30
+            contributes_to:
+              - { target: fcu_rehab_sets }
 
       - block_name: wrist_flexion_eccentrics
         size_minutes: 10
         location: anywhere
         tags: [rehab, forearm]
-        contributes_to:
-          - { target: fcu_rehab_sets }
         prescription:
           - exercise: wrist_flexion_eccentric
             sets: 3
             reps: 15
             tempo: "4010"
+            contributes_to:
+              - { target: fcu_rehab_sets }
 
   hip_flexors:
     blocks:
@@ -234,24 +244,24 @@ priorities:
         size_minutes: 6
         location: anywhere
         tags: [maintenance, core, hip_flexor]
-        contributes_to:
-          - { target: hip_flexor_sets }
         prescription:
           - exercise: deadbug
             sets: 3
             reps: 10
+            contributes_to:
+              - { target: hip_flexor_sets }
 
       - block_name: straight_leg_raises
         size_minutes: 6
         location: anywhere
         tags: [maintenance, hip_flexor]
-        contributes_to:
-          - { target: hip_flexor_sets }
         prescription:
           - exercise: straight_leg_raise
             sets: 3
             reps: 10
             per_side: true
+            contributes_to:
+              - { target: hip_flexor_sets }
 
   cardio:
     blocks:
@@ -264,11 +274,11 @@ priorities:
         size_minutes: [20, 30, 45]
         location: anywhere
         tags: [cardio, zone2, knee_light]
-        contributes_to:
-          - { target: zone2_minutes }
         prescription:
           - exercise: bike_or_row_or_treadmill
             target: Z2
+            contributes_to:
+              - { target: zone2_minutes }
             fatigue_loads:
               knee: "$performed_minutes * 0.3 / 30"
               cns: "$performed_minutes * 0.25 / 30"
@@ -277,11 +287,11 @@ priorities:
         size_minutes: 20
         location: anywhere
         tags: [cardio, zone4, knee_light]
-        contributes_to:
-          - { target: zone4_minutes }
         prescription:
           - exercise: bike_preferred
             interval_protocol: "4x4"
+            contributes_to:
+              - { target: zone4_minutes }
             fatigue_loads:
               knee: "$performed_minutes * 0.4 / 20"
               cns: 1.0
@@ -292,13 +302,13 @@ priorities:
         size_minutes: 20
         location: gym
         tags: [strength, aesthetics, compound_heavy]
-        contributes_to:
-          - { target: full_body_strength_sets }
         prescription:
           - exercise: deadlift
             sets: 3
             reps: 5
             rpe: 7
+            contributes_to:
+              - { target: full_body_strength_sets }
             fatigue_loads:
               knee: 0.6
               cns: 1.0
@@ -307,13 +317,13 @@ priorities:
         size_minutes: 20
         location: gym
         tags: [strength, aesthetics, upper_body, compound_heavy]
-        contributes_to:
-          - { target: full_body_strength_sets }
         prescription:
           - exercise: bench_press
             sets: 3
             reps: 6
             rpe: 7
+            contributes_to:
+              - { target: full_body_strength_sets }
             fatigue_loads:
               knee: 0.0
               cns: 0.5
@@ -322,13 +332,13 @@ priorities:
         size_minutes: 20
         location: gym
         tags: [strength, aesthetics, upper_body, compound_heavy]
-        contributes_to:
-          - { target: full_body_strength_sets }
         prescription:
           - exercise: overhead_press
             sets: 3
             reps: 6
             rpe: 7
+            contributes_to:
+              - { target: full_body_strength_sets }
             fatigue_loads:
               knee: 0.0
               cns: 0.5

--- a/app/src/main/java/com/chrislentner/coach/planner/model/CoachConfig.kt
+++ b/app/src/main/java/com/chrislentner/coach/planner/model/CoachConfig.kt
@@ -56,8 +56,6 @@ data class Block(
     val sizeMinutes: List<Int> = emptyList(), // Always normalized to a list
     val location: String,
     val tags: List<String> = emptyList(),
-    @JsonProperty("contributes_to")
-    val contributesTo: List<Contribution> = emptyList(),
     val prescription: List<Prescription>,
     val progression: Progression? = null
 )
@@ -82,7 +80,9 @@ data class Prescription(
     val secondsPerRep: Int? = null,
     val rpe: Int? = null,
     @JsonProperty("fatigue_loads")
-    val fatigueLoads: Map<String, Any> = emptyMap() // Can be Double or String
+    val fatigueLoads: Map<String, Any> = emptyMap(), // Can be Double or String
+    @JsonProperty("contributes_to")
+    val contributesTo: List<Contribution> = emptyList()
 )
 
 data class Progression(

--- a/app/src/test/java/com/chrislentner/coach/planner/CoachConfigTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/planner/CoachConfigTest.kt
@@ -39,11 +39,9 @@ class CoachConfigTest {
         val block = nordicSki!!.blocks.firstOrNull()
         assertNotNull(block)
 
-        // Check defaults are working (sizeMinutes empty, contributesTo empty)
+        // Check defaults are working (sizeMinutes empty)
         assertNotNull(block!!.sizeMinutes)
         assert(block.sizeMinutes.isEmpty())
-        assertNotNull(block.contributesTo)
-        assert(block.contributesTo.isEmpty())
 
         val prescription = block.prescription.firstOrNull()
         assertNotNull(prescription)

--- a/app/src/test/java/com/chrislentner/coach/planner/DeficitLogicTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/planner/DeficitLogicTest.kt
@@ -1,0 +1,141 @@
+package com.chrislentner.coach.planner
+
+import com.chrislentner.coach.database.ScheduleEntry
+import com.chrislentner.coach.database.WorkoutLogEntry
+import com.chrislentner.coach.planner.model.Block
+import com.chrislentner.coach.planner.model.CoachConfig
+import com.chrislentner.coach.planner.model.Contribution
+import com.chrislentner.coach.planner.model.FatigueConstraint
+import com.chrislentner.coach.planner.model.Prescription
+import com.chrislentner.coach.planner.model.PriorityGroup
+import com.chrislentner.coach.planner.model.SelectionStrategy
+import com.chrislentner.coach.planner.model.Target
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mockito.mock
+import java.time.Instant
+
+class DeficitLogicTest {
+
+    private lateinit var config: CoachConfig
+    private lateinit var historyAnalyzer: HistoryAnalyzer
+    private lateinit var planner: AdvancedWorkoutPlanner
+    private lateinit var progressionEngine: ProgressionEngine
+
+    @Before
+    fun setup() {
+        // Setup Config
+        val target = Target("test_target_sets", 7, "sets", 10)
+
+        // Exercise contributing to target
+        val prescription1 = Prescription(
+            exercise = "ContribExercise",
+            sets = 3,
+            contributesTo = listOf(Contribution("test_target_sets"))
+        )
+        // Exercise NOT contributing
+        val prescription2 = Prescription(
+            exercise = "AccessoryExercise",
+            sets = 3
+        )
+
+        val block = Block(
+            blockName = "TestBlock",
+            sizeMinutes = listOf(30),
+            location = "Gym",
+            prescription = listOf(prescription1, prescription2)
+        )
+
+        config = CoachConfig(
+            version = 1,
+            targets = listOf(target),
+            fatigueConstraints = emptyMap(),
+            priorityOrder = listOf("P1"),
+            priorities = mapOf("P1" to PriorityGroup(listOf(block))),
+            selection = SelectionStrategy("greedy")
+        )
+
+        historyAnalyzer = HistoryAnalyzer(config)
+        progressionEngine = ProgressionEngine(historyAnalyzer)
+        planner = AdvancedWorkoutPlanner(config, historyAnalyzer, progressionEngine)
+    }
+
+    @Test
+    fun `HistoryAnalyzer counts performed from contributing exercise`() {
+        val now = Instant.now()
+        val history = listOf(
+            // Should count
+            WorkoutLogEntry(
+                sessionId = 1,
+                exerciseName = "ContribExercise",
+                targetReps = 10,
+                targetDurationSeconds = null,
+                loadDescription = "",
+                actualReps = 10,
+                actualDurationSeconds = null,
+                rpe = null,
+                notes = null,
+                skipped = false,
+                timestamp = now.toEpochMilli()
+            ),
+            // Should NOT count
+            WorkoutLogEntry(
+                sessionId = 1,
+                exerciseName = "AccessoryExercise",
+                targetReps = 10,
+                targetDurationSeconds = null,
+                loadDescription = "",
+                actualReps = 10,
+                actualDurationSeconds = null,
+                rpe = null,
+                notes = null,
+                skipped = false,
+                timestamp = now.toEpochMilli()
+            )
+        )
+
+        val performed = historyAnalyzer.getPerformed("test_target_sets", 7, now, history)
+        assertEquals(1.0, performed, 0.0) // 1 set (log)
+    }
+
+    @Test
+    fun `AdvancedWorkoutPlanner calculates reduction from contributing exercise`() {
+        val now = Instant.now()
+        val history = emptyList<WorkoutLogEntry>() // No history, full deficit
+        val schedule = ScheduleEntry(
+            date = "2023-01-01",
+            isRestDay = false,
+            timeInMillis = null,
+            durationMinutes = 60,
+            location = "Gym"
+        )
+
+        // Deficit is 10. Goal 10. Performed 0.
+
+        val plan = planner.generatePlan(now, history, schedule)
+
+        // Should schedule the block.
+        // Block has 2 exercises (3 sets each).
+        // Only "ContribExercise" contributes.
+        // It has 3 sets.
+        // So reduction should be 3.
+        // 10 - 3 = 7.
+        // Wait, loop runs until no block added.
+        // Block size 30. Available 60.
+        // 1st pass: Deficit 10. Add block. Deficit becomes 7. Time 30.
+        // 2nd pass: Deficit 7. Add block. Deficit becomes 4. Time 0.
+        // 2 blocks scheduled. Total 2 * 3 = 6 sets reduced?
+
+        // Wait, calculateReduction Logic:
+        // returns relevantSteps.size.
+        // steps are created for each set.
+        // sets=3. So 3 steps.
+
+        // Let's verify executedBlocks reduction value.
+
+        val executions = plan.blocks
+        assertEquals(1, executions.size)
+        assertEquals(3.0, executions[0].reduction, 0.0)
+    }
+}

--- a/app/src/test/java/com/chrislentner/coach/planner/ProgressionEngineTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/planner/ProgressionEngineTest.kt
@@ -79,7 +79,6 @@ class ProgressionEngineTest {
             blockName = "Unknown",
             sizeMinutes = listOf(10),
             location = "Gym",
-            contributesTo = emptyList(),
             prescription = emptyList(),
             progression = Progression(type = "magic_growth")
         )
@@ -96,7 +95,6 @@ class ProgressionEngineTest {
             blockName = "Linear",
             sizeMinutes = listOf(30),
             location = "Gym",
-            contributesTo = emptyList(),
             prescription = listOf(Prescription(exercise = "Squat")),
             progression = Progression(
                 type = "linear_load",
@@ -111,7 +109,6 @@ class ProgressionEngineTest {
             blockName = "Cardio",
             sizeMinutes = listOf(start),
             location = "Outside",
-            contributesTo = emptyList(),
             prescription = listOf(Prescription(exercise = "Run")),
             progression = Progression(
                 type = "per_session_minutes",

--- a/app/src/test/java/com/chrislentner/coach/ui/SuggestScheduleViewModelTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/ui/SuggestScheduleViewModelTest.kt
@@ -68,7 +68,6 @@ class SuggestScheduleViewModelTest {
                 sizeMinutes = emptyList(),
                 location = "Home",
                 tags = emptyList(),
-                contributesTo = emptyList(),
                 prescription = emptyList(),
                 progression = null
             )

--- a/app/src/test/resources/test_coach.yaml
+++ b/app/src/test/resources/test_coach.yaml
@@ -30,12 +30,12 @@ priorities:
         size_minutes: [10]
         location: anywhere
         tags: [knee_heavy]
-        contributes_to:
-          - { target: t1_sets }
         prescription:
           - exercise: ex_a
             sets: 2
             reps: 5
+            contributes_to:
+              - { target: t1_sets }
             fatigue_loads:
               knee: 0.5
         progression:
@@ -51,11 +51,11 @@ priorities:
         size_minutes: [10]
         location: anywhere
         tags: []
-        contributes_to:
-          - { target: t2_minutes }
         prescription:
           - exercise: ex_b
             target: Z2
+            contributes_to:
+              - { target: t2_minutes }
             fatigue_loads: {}
 
 selection:


### PR DESCRIPTION
This change refactors the deficit calculation and workout planning logic to operate at the exercise level instead of the block level. This allows for more granular control over which exercises contribute to specific goals (e.g., only the key exercise in a mobility block contributes to mobility minutes).

Key changes:
- `CoachConfig.kt`: Moved `contributesTo` from `Block` to `Prescription`.
- `coach.yaml`: Updated configuration to define contributions on exercises.
- `HistoryAnalyzer.kt`: Updated `getPerformed` and `getLastSatisfyingSessions` to use exercise-level contributions.
- `AdvancedWorkoutPlanner.kt`: Updated `findBestBlock` and `calculateReduction` to aggregate contributions from exercises.
- Tests: Updated existing tests and added `DeficitLogicTest`.

---
*PR created automatically by Jules for task [6443103093569282949](https://jules.google.com/task/6443103093569282949) started by @clentner*