### PR TITLE
Fix UTC midnight timestamp

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
@@ -9,6 +9,8 @@ import androidx.lifecycle.viewModelScope
 import com.chrislentner.coach.database.WorkoutLogEntry
 import com.chrislentner.coach.database.WorkoutRepository
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneId
 
 class EditExerciseViewModel(
     private val repository: WorkoutRepository,
@@ -71,20 +73,15 @@ class EditExerciseViewModel(
                 )
                 repository.updateLog(updated)
             } else {
-                // Create new
-                // Need session timestamp
                 val session = repository.getSessionById(sessionId)
-                val timestamp = session?.startTimeInMillis ?: System.currentTimeMillis()
-
-                // Add a small offset to ensure it appears at the end if added now?
-                // No, just use session start time. Order is by timestamp.
-                // If multiple logs have same timestamp, order is undefined or by ID?
-                // Log ID is auto-inc, so insertion order might matter if sorted by ID, but Query sorts by timestamp.
-                // If timestamp is identical, order is unstable.
-                // Maybe add current time offset?
-                // session.startTime + (System.now - session.startTime) ? No that's now.
-                // session.startTime + 1 hour?
-                // Let's just use session.startTimeInMillis.
+                val timestamp = if (session != null) {
+                    LocalDate.parse(session.date)
+                        .atStartOfDay(ZoneId.systemDefault())
+                        .toInstant()
+                        .toEpochMilli()
+                } else {
+                    System.currentTimeMillis()
+                }
 
                 val newEntry = WorkoutLogEntry(
                     sessionId = sessionId,

--- a/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
@@ -14,6 +14,8 @@ import org.junit.Test
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.Shadows.shadowOf
+import java.time.LocalDate
+import java.time.ZoneId
 
 @RunWith(RobolectricTestRunner::class)
 class EditExerciseViewModelTest {
@@ -60,10 +62,8 @@ class EditExerciseViewModelTest {
     }
 
     @Test
-    fun `save creates new log with session timestamp`() {
-        // Setup session
-        val sessionTimestamp = 1000L
-        val session = WorkoutSession(id=1, date="2023-01-01", startTimeInMillis=sessionTimestamp, isCompleted=false)
+    fun `save creates new log with local midnight timestamp from session date`() {
+        val session = WorkoutSession(id=1, date="2023-01-01", startTimeInMillis=1000L, isCompleted=false)
         dao.sessions.add(session)
 
         val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null)
@@ -79,7 +79,11 @@ class EditExerciseViewModelTest {
         assertEquals(1, dao.logs.size)
         val log = dao.logs.first()
         assertEquals("Squat", log.exerciseName)
-        assertEquals(sessionTimestamp, log.timestamp)
+        val expectedTimestamp = LocalDate.parse("2023-01-01")
+            .atStartOfDay(ZoneId.systemDefault())
+            .toInstant()
+            .toEpochMilli()
+        assertEquals(expectedTimestamp, log.timestamp)
     }
 
     @Test


### PR DESCRIPTION
DatePicker returns UTC midnight millis for the selected date, and this was passed through as the log entry timestamp via session.startTimeInMillis. For users in western timezones (e.g. EST = UTC-5), "Feb 9" becomes Feb 9 00:00 UTC = Feb 8 7PM local. When checking status late on Feb 11, the 72h cutoff can land *after* that timestamp, dropping the entries from the fatigue window while the 7-day target window still includes them.

Derive the timestamp from the session's date string in the user's local timezone instead, so the entry lands at the actual start of that day.