### PR TITLE
Feature: Custom Targets and Fatigue Overrides for Logs

### DIFF
--- a/app/schemas/com.chrislentner.coach.database.AppDatabase/9.json
+++ b/app/schemas/com.chrislentner.coach.database.AppDatabase/9.json
@@ -1,0 +1,284 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 9,
+    "identityHash": "c627ecdda20a487534a59ab900fe087c",
+    "entities": [
+      {
+        "tableName": "User",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`uid` INTEGER NOT NULL, `firstName` TEXT, `lastName` TEXT, PRIMARY KEY(`uid`))",
+        "fields": [
+          {
+            "fieldPath": "uid",
+            "columnName": "uid",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "firstName",
+            "columnName": "firstName",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastName",
+            "columnName": "lastName",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "uid"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "schedule_entries",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`date` TEXT NOT NULL, `timeInMillis` INTEGER, `durationMinutes` INTEGER, `location` TEXT, `isRestDay` INTEGER NOT NULL, PRIMARY KEY(`date`))",
+        "fields": [
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timeInMillis",
+            "columnName": "timeInMillis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "durationMinutes",
+            "columnName": "durationMinutes",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isRestDay",
+            "columnName": "isRestDay",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "date"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "workout_sessions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `date` TEXT NOT NULL, `startTimeInMillis` INTEGER NOT NULL, `endTimeInMillis` INTEGER, `isCompleted` INTEGER NOT NULL, `location` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "startTimeInMillis",
+            "columnName": "startTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "endTimeInMillis",
+            "columnName": "endTimeInMillis",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "isCompleted",
+            "columnName": "isCompleted",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "location",
+            "columnName": "location",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "workout_logs",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `sessionId` INTEGER NOT NULL, `exerciseName` TEXT NOT NULL, `targetReps` INTEGER, `targetDurationSeconds` INTEGER, `loadDescription` TEXT NOT NULL, `tempo` TEXT, `actualReps` INTEGER, `actualDurationSeconds` INTEGER, `rpe` INTEGER, `notes` TEXT, `skipped` INTEGER NOT NULL, `timestamp` INTEGER NOT NULL, `customTargets` TEXT, `customFatigue` TEXT, FOREIGN KEY(`sessionId`) REFERENCES `workout_sessions`(`id`) ON UPDATE NO ACTION ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "sessionId",
+            "columnName": "sessionId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "exerciseName",
+            "columnName": "exerciseName",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "targetReps",
+            "columnName": "targetReps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "targetDurationSeconds",
+            "columnName": "targetDurationSeconds",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "loadDescription",
+            "columnName": "loadDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "tempo",
+            "columnName": "tempo",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actualReps",
+            "columnName": "actualReps",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "actualDurationSeconds",
+            "columnName": "actualDurationSeconds",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "rpe",
+            "columnName": "rpe",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "notes",
+            "columnName": "notes",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "skipped",
+            "columnName": "skipped",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "customTargets",
+            "columnName": "customTargets",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "customFatigue",
+            "columnName": "customFatigue",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_workout_logs_sessionId",
+            "unique": false,
+            "columnNames": [
+              "sessionId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_logs_sessionId` ON `${TABLE_NAME}` (`sessionId`)"
+          },
+          {
+            "name": "index_workout_logs_timestamp",
+            "unique": false,
+            "columnNames": [
+              "timestamp"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_logs_timestamp` ON `${TABLE_NAME}` (`timestamp`)"
+          },
+          {
+            "name": "index_workout_logs_exerciseName",
+            "unique": false,
+            "columnNames": [
+              "exerciseName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_workout_logs_exerciseName` ON `${TABLE_NAME}` (`exerciseName`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "workout_sessions",
+            "onDelete": "CASCADE",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "sessionId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'c627ecdda20a487534a59ab900fe087c')"
+    ]
+  }
+}

--- a/app/src/main/java/com/chrislentner/coach/database/AppDatabase.kt
+++ b/app/src/main/java/com/chrislentner/coach/database/AppDatabase.kt
@@ -4,6 +4,8 @@ import androidx.room.Database
 import androidx.room.RoomDatabase
 import androidx.room.Entity
 import androidx.room.PrimaryKey
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 
 @Entity
 data class User(
@@ -12,7 +14,7 @@ data class User(
     val lastName: String?
 )
 
-@Database(entities = [User::class, ScheduleEntry::class, WorkoutSession::class, WorkoutLogEntry::class], version = 8, exportSchema = true)
+@Database(entities = [User::class, ScheduleEntry::class, WorkoutSession::class, WorkoutLogEntry::class], version = 9, exportSchema = true)
 abstract class AppDatabase : RoomDatabase() {
     // abstract fun userDao(): UserDao
     abstract fun scheduleDao(): ScheduleDao
@@ -22,6 +24,13 @@ abstract class AppDatabase : RoomDatabase() {
         @Volatile
         private var INSTANCE: AppDatabase? = null
 
+        private val MIGRATION_8_9 = object : Migration(8, 9) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                db.execSQL("ALTER TABLE workout_logs ADD COLUMN customTargets TEXT")
+                db.execSQL("ALTER TABLE workout_logs ADD COLUMN customFatigue TEXT")
+            }
+        }
+
         fun getDatabase(context: android.content.Context): AppDatabase {
             return INSTANCE ?: synchronized(this) {
                 val instance = androidx.room.Room.databaseBuilder(
@@ -29,6 +38,7 @@ abstract class AppDatabase : RoomDatabase() {
                     AppDatabase::class.java,
                     "coach-database"
                 )
+                    .addMigrations(MIGRATION_8_9)
                     .build()
                 INSTANCE = instance
                 instance

--- a/app/src/main/java/com/chrislentner/coach/database/WorkoutLogEntry.kt
+++ b/app/src/main/java/com/chrislentner/coach/database/WorkoutLogEntry.kt
@@ -35,7 +35,9 @@ data class WorkoutLogEntry(
     val rpe: Int?, // 1-10
     val notes: String?,
     val skipped: Boolean = false,
-    val timestamp: Long
+    val timestamp: Long,
+    val customTargets: String? = null,
+    val customFatigue: String? = null
 ) {
     init {
         if (tempo != null) {

--- a/app/src/main/java/com/chrislentner/coach/planner/HistoryAnalyzer.kt
+++ b/app/src/main/java/com/chrislentner/coach/planner/HistoryAnalyzer.kt
@@ -3,6 +3,8 @@ package com.chrislentner.coach.planner
 import com.chrislentner.coach.database.WorkoutLogEntry
 import com.chrislentner.coach.planner.model.Block
 import com.chrislentner.coach.planner.model.CoachConfig
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
 import java.time.Duration
 import java.time.Instant
 import kotlin.math.max
@@ -46,6 +48,19 @@ class HistoryAnalyzer(private val config: CoachConfig) {
     }
 
     private fun calculateFatigueLoad(log: WorkoutLogEntry, kind: String): Double? {
+        val customFatigueStr = log.customFatigue
+        if (customFatigueStr != null && customFatigueStr.isNotBlank()) {
+            try {
+                val mapper = jacksonObjectMapper()
+                val customMap: Map<String, Double> = mapper.readValue(customFatigueStr)
+                if (customMap.containsKey(kind)) {
+                    return customMap[kind]
+                }
+            } catch (e: Exception) {
+                // Ignore parse errors, fallback to default
+            }
+        }
+
         val fatigueDef = exerciseFatigueMap[log.exerciseName]
         if (fatigueDef != null && fatigueDef.containsKey(kind)) {
             val valOrFormula = fatigueDef[kind]
@@ -80,6 +95,22 @@ class HistoryAnalyzer(private val config: CoachConfig) {
         return getFatigueContributions(kind, windowHours, now, history).sumOf { it.load }
     }
 
+    private fun getCustomTargetValue(log: WorkoutLogEntry, targetId: String): Double? {
+        val customTargetsStr = log.customTargets
+        if (customTargetsStr != null && customTargetsStr.isNotBlank()) {
+            try {
+                val mapper = jacksonObjectMapper()
+                val customMap: Map<String, Double> = mapper.readValue(customTargetsStr)
+                if (customMap.containsKey(targetId)) {
+                    return customMap[targetId]
+                }
+            } catch (e: Exception) {
+                // Ignore parse errors, return null
+            }
+        }
+        return null
+    }
+
     fun getTargetContributions(targetId: String, windowDays: Int, now: Instant, history: List<WorkoutLogEntry>): List<TargetContribution> {
         val targetConfig = config.targets.find { it.id == targetId } ?: return emptyList()
         val cutoff = now.minus(Duration.ofDays(windowDays.toLong())).toEpochMilli()
@@ -87,16 +118,23 @@ class HistoryAnalyzer(private val config: CoachConfig) {
 
         val contributingExercises = targetContributingExercises[targetId] ?: emptySet()
 
-        return history.filter { it.timestamp in cutoff..nowMillis && contributingExercises.contains(it.exerciseName) && !it.skipped }
-            .map { log ->
-                val value = if (targetConfig.type == "sets") {
-                    1.0
-                } else if (targetConfig.type == "minutes") {
-                    (log.actualDurationSeconds ?: 0) / 60.0
+        return history.filter { it.timestamp in cutoff..nowMillis && !it.skipped }
+            .mapNotNull { log ->
+                val customValue = getCustomTargetValue(log, targetId)
+                if (customValue != null) {
+                    TargetContribution(log, customValue)
+                } else if (contributingExercises.contains(log.exerciseName)) {
+                    val value = if (targetConfig.type == "sets") {
+                        1.0
+                    } else if (targetConfig.type == "minutes") {
+                        (log.actualDurationSeconds ?: 0) / 60.0
+                    } else {
+                        0.0
+                    }
+                    TargetContribution(log, value)
                 } else {
-                    0.0
+                    null
                 }
-                TargetContribution(log, value)
             }
     }
 

--- a/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/CoachApp.kt
@@ -84,7 +84,7 @@ fun CoachApp(
             val logId = if (logIdArg == -1L) null else logIdArg
 
             val viewModel: EditExerciseViewModel = viewModel(
-                factory = EditExerciseViewModelFactory(workoutRepository, sessionId, logId)
+                factory = EditExerciseViewModelFactory(workoutRepository, sessionId, logId, planner)
             )
             EditExerciseScreen(navController = navController, viewModel = viewModel)
         }

--- a/app/src/main/java/com/chrislentner/coach/ui/EditExerciseScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/EditExerciseScreen.kt
@@ -18,12 +18,25 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.TextButton
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.navigation.NavController
@@ -65,6 +78,7 @@ fun EditExerciseScreen(
                 .fillMaxSize()
                 .padding(innerPadding)
                 .padding(16.dp)
+                .verticalScroll(rememberScrollState())
         ) {
             ExerciseEntryForm(
                 exerciseName = viewModel.exerciseName,
@@ -83,6 +97,176 @@ fun EditExerciseScreen(
                 },
                 modifier = Modifier.fillMaxWidth()
             )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            // Custom Targets & Fatigue section
+            if (viewModel.planner != null) {
+                var showAddTargetDialog by remember { mutableStateOf(false) }
+                var showAddFatigueDialog by remember { mutableStateOf(false) }
+
+                Column(modifier = Modifier.fillMaxWidth()) {
+                    Text("Targets", style = MaterialTheme.typography.titleMedium)
+                    viewModel.customTargets.forEach { (id, value) ->
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                            Text(text = "$id: $value", modifier = Modifier.weight(1f))
+                            TextButton(onClick = { viewModel.removeTarget(id) }) {
+                                Text("Remove")
+                            }
+                        }
+                    }
+                    Button(onClick = { showAddTargetDialog = true }) {
+                        Text("Add Target")
+                    }
+
+                    Spacer(modifier = Modifier.height(16.dp))
+
+                    Text("Fatigue Constraints", style = MaterialTheme.typography.titleMedium)
+                    viewModel.customFatigue.forEach { (kind, value) ->
+                        Row(modifier = Modifier.fillMaxWidth().padding(vertical = 4.dp)) {
+                            Text(text = "$kind: $value", modifier = Modifier.weight(1f))
+                            TextButton(onClick = { viewModel.removeFatigue(kind) }) {
+                                Text("Remove")
+                            }
+                        }
+                    }
+                    Button(onClick = { showAddFatigueDialog = true }) {
+                        Text("Add Fatigue")
+                    }
+                }
+
+                if (showAddTargetDialog) {
+                    var selectedTargetId by remember { mutableStateOf(viewModel.allTargetIds.firstOrNull() ?: "") }
+                    var targetAmount by remember { mutableStateOf(viewModel.getDefaultTargetValue(selectedTargetId).toString()) }
+                    var expanded by remember { mutableStateOf(false) }
+
+                    AlertDialog(
+                        onDismissRequest = { showAddTargetDialog = false },
+                        title = { Text("Add Target") },
+                        text = {
+                            Column {
+                                Box {
+                                    OutlinedTextField(
+                                        value = selectedTargetId,
+                                        onValueChange = {},
+                                        readOnly = true,
+                                        label = { Text("Target") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                    Box(
+                                        modifier = Modifier.matchParentSize().clickable { expanded = true }
+                                    )
+                                    DropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = { expanded = false }
+                                    ) {
+                                        viewModel.allTargetIds.forEach { id ->
+                                            DropdownMenuItem(
+                                                text = { Text(id) },
+                                                onClick = {
+                                                    selectedTargetId = id
+                                                    targetAmount = viewModel.getDefaultTargetValue(id).toString()
+                                                    expanded = false
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                OutlinedTextField(
+                                    value = targetAmount,
+                                    onValueChange = { targetAmount = it },
+                                    label = { Text("Amount") },
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        },
+                        confirmButton = {
+                            Button(onClick = {
+                                val amount = targetAmount.toDoubleOrNull()
+                                if (amount != null && selectedTargetId.isNotEmpty()) {
+                                    viewModel.addTarget(selectedTargetId, amount)
+                                }
+                                showAddTargetDialog = false
+                            }) {
+                                Text("Add")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showAddTargetDialog = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
+                }
+
+                if (showAddFatigueDialog) {
+                    var selectedFatigueKind by remember { mutableStateOf(viewModel.allFatigueKinds.firstOrNull() ?: "") }
+                    var fatigueAmount by remember { mutableStateOf(viewModel.getDefaultFatigueValue(selectedFatigueKind).toString()) }
+                    var expanded by remember { mutableStateOf(false) }
+
+                    AlertDialog(
+                        onDismissRequest = { showAddFatigueDialog = false },
+                        title = { Text("Add Fatigue") },
+                        text = {
+                            Column {
+                                Box {
+                                    OutlinedTextField(
+                                        value = selectedFatigueKind,
+                                        onValueChange = {},
+                                        readOnly = true,
+                                        label = { Text("Fatigue Kind") },
+                                        modifier = Modifier.fillMaxWidth()
+                                    )
+                                    Box(
+                                        modifier = Modifier.matchParentSize().clickable { expanded = true }
+                                    )
+                                    DropdownMenu(
+                                        expanded = expanded,
+                                        onDismissRequest = { expanded = false }
+                                    ) {
+                                        viewModel.allFatigueKinds.forEach { kind ->
+                                            DropdownMenuItem(
+                                                text = { Text(kind) },
+                                                onClick = {
+                                                    selectedFatigueKind = kind
+                                                    fatigueAmount = viewModel.getDefaultFatigueValue(kind).toString()
+                                                    expanded = false
+                                                }
+                                            )
+                                        }
+                                    }
+                                }
+                                Spacer(modifier = Modifier.height(8.dp))
+                                OutlinedTextField(
+                                    value = fatigueAmount,
+                                    onValueChange = { fatigueAmount = it },
+                                    label = { Text("Amount") },
+                                    keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+                                    modifier = Modifier.fillMaxWidth()
+                                )
+                            }
+                        },
+                        confirmButton = {
+                            Button(onClick = {
+                                val amount = fatigueAmount.toDoubleOrNull()
+                                if (amount != null && selectedFatigueKind.isNotEmpty()) {
+                                    viewModel.addFatigue(selectedFatigueKind, amount)
+                                }
+                                showAddFatigueDialog = false
+                            }) {
+                                Text("Add")
+                            }
+                        },
+                        dismissButton = {
+                            TextButton(onClick = { showAddFatigueDialog = false }) {
+                                Text("Cancel")
+                            }
+                        }
+                    )
+                }
+            }
 
             Spacer(modifier = Modifier.height(32.dp))
 

--- a/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
@@ -7,15 +7,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
 import com.chrislentner.coach.database.WorkoutLogEntry
+import androidx.compose.runtime.mutableStateMapOf
 import com.chrislentner.coach.database.WorkoutRepository
 import kotlinx.coroutines.launch
 import java.time.LocalDate
 import java.time.ZoneId
 
+import com.chrislentner.coach.planner.AdvancedWorkoutPlanner
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+
 class EditExerciseViewModel(
     private val repository: WorkoutRepository,
     private val sessionId: Long,
-    private val logId: Long?
+    private val logId: Long?,
+    val planner: AdvancedWorkoutPlanner?
 ) : ViewModel() {
 
     var exerciseName by mutableStateOf("")
@@ -24,10 +30,19 @@ class EditExerciseViewModel(
     var durationMinutes by mutableStateOf("")
     var tempo by mutableStateOf("")
 
+    val customTargets = mutableStateMapOf<String, Double>()
+    val customFatigue = mutableStateMapOf<String, Double>()
+
     val isEditing: Boolean
         get() = logId != null && logId != -1L
 
     private var existingLog: WorkoutLogEntry? = null
+
+    val allTargetIds: List<String>
+        get() = planner?.config?.targets?.map { it.id } ?: emptyList()
+
+    val allFatigueKinds: List<String>
+        get() = planner?.config?.fatigueConstraints?.keys?.toList() ?: emptyList()
 
     init {
         if (isEditing) {
@@ -40,6 +55,20 @@ class EditExerciseViewModel(
                     reps = log.targetReps?.toString() ?: ""
                     durationMinutes = log.targetDurationSeconds?.let { (it / 60).toString() } ?: ""
                     tempo = log.tempo ?: ""
+
+                    try {
+                        val mapper = jacksonObjectMapper()
+                        if (!log.customTargets.isNullOrBlank()) {
+                            val targets: Map<String, Double> = mapper.readValue(log.customTargets)
+                            customTargets.putAll(targets)
+                        }
+                        if (!log.customFatigue.isNullOrBlank()) {
+                            val fatigue: Map<String, Double> = mapper.readValue(log.customFatigue)
+                            customFatigue.putAll(fatigue)
+                        }
+                    } catch (e: Exception) {
+                        // ignore parse errors
+                    }
                 }
             }
         }
@@ -60,11 +89,42 @@ class EditExerciseViewModel(
         }
     }
 
+    fun addTarget(id: String, value: Double) {
+        customTargets[id] = value
+    }
+
+    fun removeTarget(id: String) {
+        customTargets.remove(id)
+    }
+
+    fun addFatigue(kind: String, value: Double) {
+        customFatigue[kind] = value
+    }
+
+    fun removeFatigue(kind: String) {
+        customFatigue.remove(kind)
+    }
+
+    fun getDefaultTargetValue(id: String): Double {
+        val target = planner?.config?.targets?.find { it.id == id }
+        return target?.goal?.toDouble() ?: 0.0
+    }
+
+    fun getDefaultFatigueValue(kind: String): Double {
+        // Fallback to first constraint if exercise doesn't have a default
+        val constraint = planner?.config?.fatigueConstraints?.get(kind)?.firstOrNull()
+        return constraint?.threshold ?: 1.0
+    }
+
     fun save(onSuccess: () -> Unit) {
         viewModelScope.launch {
             val repsInt = reps.toIntOrNull()
             val durationSecondsInt = durationMinutes.toIntOrNull()?.let { it * 60 }
             val validTempo = if (tempo.length == 4 && tempo.all { it.isDigit() }) tempo else null
+
+            val mapper = jacksonObjectMapper()
+            val customTargetsStr = if (customTargets.isNotEmpty()) mapper.writeValueAsString(customTargets) else null
+            val customFatigueStr = if (customFatigue.isNotEmpty()) mapper.writeValueAsString(customFatigue) else null
 
             if (existingLog != null) {
                 // Update existing
@@ -75,7 +135,9 @@ class EditExerciseViewModel(
                     actualReps = repsInt,
                     targetDurationSeconds = durationSecondsInt,
                     actualDurationSeconds = durationSecondsInt,
-                    tempo = validTempo
+                    tempo = validTempo,
+                    customTargets = customTargetsStr,
+                    customFatigue = customFatigueStr
                 )
                 repository.updateLog(updated)
             } else {
@@ -101,7 +163,9 @@ class EditExerciseViewModel(
                     rpe = null,
                     notes = "Manual Entry",
                     skipped = false,
-                    timestamp = timestamp
+                    timestamp = timestamp,
+                    customTargets = customTargetsStr,
+                    customFatigue = customFatigueStr
                 )
                 repository.logSet(newEntry)
             }
@@ -122,12 +186,13 @@ class EditExerciseViewModel(
 class EditExerciseViewModelFactory(
     private val repository: WorkoutRepository,
     private val sessionId: Long,
-    private val logId: Long?
+    private val logId: Long?,
+    private val planner: AdvancedWorkoutPlanner?
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(EditExerciseViewModel::class.java)) {
             @Suppress("UNCHECKED_CAST")
-            return EditExerciseViewModel(repository, sessionId, logId) as T
+            return EditExerciseViewModel(repository, sessionId, logId, planner) as T
         }
         throw IllegalArgumentException("Unknown ViewModel class")
     }

--- a/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
@@ -66,7 +66,7 @@ class EditExerciseViewModelTest {
         val session = WorkoutSession(id=1, date="2023-01-01", startTimeInMillis=1000L, isCompleted=false)
         dao.sessions.add(session)
 
-        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null)
+        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null, planner=null)
         viewModel.exerciseName = "Squat"
         viewModel.load = "100"
         viewModel.reps = "5"
@@ -94,7 +94,7 @@ class EditExerciseViewModelTest {
         val existingLog = WorkoutLogEntry(id=1, sessionId=1, exerciseName="Squat", targetReps=5, targetDurationSeconds=null, loadDescription="100", timestamp=1000L, actualReps=5, actualDurationSeconds=null, rpe=null, notes=null)
         dao.logs.add(existingLog)
 
-        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=1)
+        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=1, planner=null)
         shadowOf(Looper.getMainLooper()).idle() // let init run
 
         assertEquals("Squat", viewModel.exerciseName)
@@ -118,7 +118,7 @@ class EditExerciseViewModelTest {
         val existingLog = WorkoutLogEntry(id=1, sessionId=1, exerciseName="Squat", targetReps=5, targetDurationSeconds=null, loadDescription="100", timestamp=1000L, actualReps=5, actualDurationSeconds=null, rpe=null, notes=null)
         dao.logs.add(existingLog)
 
-        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=1)
+        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=1, planner=null)
         shadowOf(Looper.getMainLooper()).idle() // let init run
 
         var successCalled = false
@@ -140,7 +140,7 @@ class EditExerciseViewModelTest {
         )
         dao.logs.add(lastLog)
 
-        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null)
+        val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null, planner=null)
         shadowOf(Looper.getMainLooper()).idle()
 
         viewModel.onExerciseSelected("Deadlift")


### PR DESCRIPTION
Adds functionality to allow users to override the default target contributions and fatigue constraints for an exercise on a per-log basis from the "Past Workouts" editing screen. Custom overrides are stored as JSON strings in the Room database and are incorporated correctly by the HistoryAnalyzer.

---
*PR created automatically by Jules for task [8945488825974855011](https://jules.google.com/task/8945488825974855011) started by @clentner*