### PR TITLE
Add Time Picker for Past Workouts

### DIFF
--- a/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
@@ -142,7 +142,12 @@ class EditExerciseViewModel(
                 repository.updateLog(updated)
             } else {
                 val session = repository.getSessionById(sessionId)
-                val timestamp = session?.startTimeInMillis ?: System.currentTimeMillis()
+                val isToday = session != null && session.date == LocalDate.now(ZoneId.systemDefault()).toString()
+                val timestamp = if (session != null && !isToday) {
+                    session.startTimeInMillis
+                } else {
+                    System.currentTimeMillis()
+                }
 
                 val newEntry = WorkoutLogEntry(
                     sessionId = sessionId,

--- a/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/EditExerciseViewModel.kt
@@ -142,14 +142,7 @@ class EditExerciseViewModel(
                 repository.updateLog(updated)
             } else {
                 val session = repository.getSessionById(sessionId)
-                val timestamp = if (session != null) {
-                    LocalDate.parse(session.date)
-                        .atStartOfDay(ZoneId.systemDefault())
-                        .toInstant()
-                        .toEpochMilli()
-                } else {
-                    System.currentTimeMillis()
-                }
+                val timestamp = session?.startTimeInMillis ?: System.currentTimeMillis()
 
                 val newEntry = WorkoutLogEntry(
                     sessionId = sessionId,

--- a/app/src/main/java/com/chrislentner/coach/ui/PastWorkoutsScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/PastWorkoutsScreen.kt
@@ -22,7 +22,9 @@ fun PastWorkoutsScreen(
     viewModel: PastWorkoutsViewModel
 ) {
     var showDatePicker by remember { mutableStateOf(false) }
+    var showTimePicker by remember { mutableStateOf(false) }
     val datePickerState = rememberDatePickerState()
+    val timePickerState = rememberTimePickerState(initialHour = 12, initialMinute = 0)
 
     if (showDatePicker) {
         DatePickerDialog(
@@ -30,16 +32,13 @@ fun PastWorkoutsScreen(
             confirmButton = {
                 TextButton(
                     onClick = {
-                        val selectedDate = datePickerState.selectedDateMillis
-                        if (selectedDate != null) {
-                            viewModel.createSession(selectedDate) { sessionId ->
-                                showDatePicker = false
-                                navController.navigate("workout_detail/$sessionId")
-                            }
+                        if (datePickerState.selectedDateMillis != null) {
+                            showDatePicker = false
+                            showTimePicker = true
                         }
                     }
                 ) {
-                    Text("OK")
+                    Text("Next")
                 }
             },
             dismissButton = {
@@ -50,6 +49,42 @@ fun PastWorkoutsScreen(
         ) {
             DatePicker(state = datePickerState)
         }
+    }
+
+    if (showTimePicker) {
+        AlertDialog(
+            onDismissRequest = { showTimePicker = false },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        val selectedDate = datePickerState.selectedDateMillis
+                        if (selectedDate != null) {
+                            viewModel.createSession(
+                                dateMillis = selectedDate,
+                                hour = timePickerState.hour,
+                                minute = timePickerState.minute
+                            ) { sessionId ->
+                                showTimePicker = false
+                                navController.navigate("workout_detail/$sessionId")
+                            }
+                        }
+                    }
+                ) {
+                    Text("OK")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showTimePicker = false }) {
+                    Text("Cancel")
+                }
+            },
+            title = { Text("Select Time") },
+            text = {
+                Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxWidth()) {
+                    TimeInput(state = timePickerState)
+                }
+            }
+        )
     }
 
     Scaffold(

--- a/app/src/main/java/com/chrislentner/coach/ui/PastWorkoutsViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/PastWorkoutsViewModel.kt
@@ -35,15 +35,19 @@ class PastWorkoutsViewModel(
         }
     }
 
-    fun createSession(millis: Long, onCreated: (Long) -> Unit) {
+    fun createSession(dateMillis: Long, hour: Int, minute: Int, onCreated: (Long) -> Unit) {
         viewModelScope.launch {
             val formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd", Locale.US)
-            val dateStr = Instant.ofEpochMilli(millis)
+            val localDate = Instant.ofEpochMilli(dateMillis)
                 .atZone(ZoneOffset.UTC)
                 .toLocalDate()
-                .format(formatter)
+            val dateStr = localDate.format(formatter)
 
-            val session = repository.getOrCreateSession(dateStr, millis)
+            val localTime = java.time.LocalTime.of(hour, minute)
+            val localDateTime = java.time.LocalDateTime.of(localDate, localTime)
+            val timestamp = localDateTime.atZone(ZoneId.systemDefault()).toInstant().toEpochMilli()
+
+            val session = repository.getOrCreateSession(dateStr, timestamp)
             onCreated(session.id)
         }
     }

--- a/app/src/main/java/com/chrislentner/coach/ui/WorkoutViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/WorkoutViewModel.kt
@@ -166,7 +166,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = null,
                     skipped = false,
-                    timestamp = state.session.startTimeInMillis
+                    timestamp = System.currentTimeMillis()
                 )
                 repository.logSet(entry)
 
@@ -198,7 +198,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = null,
                     skipped = true,
-                    timestamp = state.session.startTimeInMillis
+                    timestamp = System.currentTimeMillis()
                 )
                 repository.logSet(entry)
 
@@ -227,7 +227,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = "Free Entry",
                     skipped = false,
-                    timestamp = state.session.startTimeInMillis
+                    timestamp = System.currentTimeMillis()
                 )
                 repository.logSet(entry)
                 // Stay in Free Entry mode, maybe show a toast or clear inputs?

--- a/app/src/main/java/com/chrislentner/coach/ui/WorkoutViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/WorkoutViewModel.kt
@@ -166,7 +166,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = null,
                     skipped = false,
-                    timestamp = System.currentTimeMillis()
+                    timestamp = state.session.startTimeInMillis
                 )
                 repository.logSet(entry)
 
@@ -198,7 +198,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = null,
                     skipped = true,
-                    timestamp = System.currentTimeMillis()
+                    timestamp = state.session.startTimeInMillis
                 )
                 repository.logSet(entry)
 
@@ -227,7 +227,7 @@ class WorkoutViewModel(
                     rpe = null,
                     notes = "Free Entry",
                     skipped = false,
-                    timestamp = System.currentTimeMillis()
+                    timestamp = state.session.startTimeInMillis
                 )
                 repository.logSet(entry)
                 // Stay in Free Entry mode, maybe show a toast or clear inputs?

--- a/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
+++ b/app/src/test/java/com/chrislentner/coach/ui/EditExerciseViewModelTest.kt
@@ -66,8 +66,9 @@ class EditExerciseViewModelTest {
     }
 
     @Test
-    fun `save creates new log with local midnight timestamp from session date`() {
-        val session = WorkoutSession(id=1, date="2023-01-01", startTimeInMillis=1000L, isCompleted=false)
+    fun `save creates new log with session start timestamp`() {
+        val expectedTimestamp = 1672531200000L
+        val session = WorkoutSession(id=1, date="2023-01-01", startTimeInMillis=expectedTimestamp, isCompleted=false)
         dao.sessions.add(session)
 
         val viewModel = EditExerciseViewModel(repository, sessionId=1, logId=null, planner=null)
@@ -83,10 +84,6 @@ class EditExerciseViewModelTest {
         assertEquals(1, dao.logs.size)
         val log = dao.logs.first()
         assertEquals("Squat", log.exerciseName)
-        val expectedTimestamp = LocalDate.parse("2023-01-01")
-            .atStartOfDay(ZoneId.systemDefault())
-            .toInstant()
-            .toEpochMilli()
         assertEquals(expectedTimestamp, log.timestamp)
     }
 


### PR DESCRIPTION
Currently, when a user adds a past workout, the system automatically zeroes the local time to UTC midnight on the chosen date. This behavior is problematic since precise time records are required for decay operations and fatigue constraints (especially considering varying windows for rolling loads). 

This PR addresses this by:
1. Adding a `TimeInput` state inside an `AlertDialog` in the `PastWorkoutsScreen` that follows immediately after selecting the `DatePicker`.
2. Altering `createSession` in `PastWorkoutsViewModel` to accept `hour` and `minute` arguments, accurately formatting a local date-time stamp to pass to the repository instead of the `dateMillis` which assumes UTC midnight.

---
*PR created automatically by Jules for task [9590329120278216165](https://jules.google.com/task/9590329120278216165) started by @clentner*