### PR TITLE
Add Garmin daily steps to Health Connect debug screen

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
     <uses-permission android:name="android.permission.health.READ_EXERCISE"/>
     <uses-permission android:name="android.permission.health.READ_HEART_RATE"/>
+    <uses-permission android:name="android.permission.health.READ_STEPS"/>
 
     <queries>
         <package android:name="com.google.android.apps.healthdata" />

--- a/app/src/main/java/com/chrislentner/coach/health/HealthConnectManager.kt
+++ b/app/src/main/java/com/chrislentner/coach/health/HealthConnectManager.kt
@@ -7,6 +7,9 @@ import androidx.health.connect.client.PermissionController
 import androidx.health.connect.client.permission.HealthPermission
 import androidx.health.connect.client.records.ExerciseSessionRecord
 import androidx.health.connect.client.records.HeartRateRecord
+import androidx.health.connect.client.records.StepsRecord
+import androidx.health.connect.client.records.metadata.DataOrigin
+import androidx.health.connect.client.request.AggregateRequest
 import androidx.health.connect.client.request.ReadRecordsRequest
 import androidx.health.connect.client.time.TimeRangeFilter
 import android.content.Intent
@@ -73,7 +76,8 @@ object HealthConnectManager {
     fun getRequiredPermissions(): Set<String> {
         return setOf(
             HealthPermission.getReadPermission(ExerciseSessionRecord::class),
-            HealthPermission.getReadPermission(HeartRateRecord::class)
+            HealthPermission.getReadPermission(HeartRateRecord::class),
+            HealthPermission.getReadPermission(StepsRecord::class)
         )
     }
 
@@ -115,6 +119,20 @@ object HealthConnectManager {
         )
         val response = client.readRecords(request)
         return response.records
+    }
+
+    suspend fun readDailyGarminSteps(
+        client: HealthConnectClient,
+        startInstant: Instant,
+        endInstant: Instant
+    ): Long? {
+        val request = AggregateRequest(
+            metrics = setOf(StepsRecord.COUNT_TOTAL),
+            timeRangeFilter = TimeRangeFilter.between(startInstant, endInstant),
+            dataOriginFilter = setOf(DataOrigin("com.garmin.android.apps.connectmobile"))
+        )
+        val response = client.aggregate(request)
+        return response[StepsRecord.COUNT_TOTAL]
     }
 
     fun flattenHeartRateSamples(records: List<HeartRateRecord>): List<FlattenedHrSample> {

--- a/app/src/main/java/com/chrislentner/coach/ui/HealthConnectDebugScreen.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/HealthConnectDebugScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.ui.Alignment
+import androidx.compose.foundation.clickable
 import androidx.health.connect.client.HealthConnectClient
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
@@ -75,6 +76,13 @@ fun HealthConnectDebugScreen(
             ZoneConfigSection(
                 maxHrInput = state.maxHrInput,
                 onMaxHrChange = { viewModel.updateMaxHr(it) }
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            DailyStepsSection(
+                state = state,
+                onToggleExpanded = { viewModel.toggleStepExpanded(it) }
             )
 
             Spacer(modifier = Modifier.height(16.dp))
@@ -185,6 +193,76 @@ fun SessionDebugCard(
             } else {
                 if (model.computedZones != null) {
                     Text("Samples: ${model.computedZones.sampleCount} | Avg HR: ${model.computedZones.avgHr ?: "N/A"}")
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun DailyStepsSection(state: HealthConnectState, onToggleExpanded: (java.time.LocalDate) -> Unit) {
+    Card(modifier = Modifier.fillMaxWidth()) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text("Daily Steps (Garmin)", style = MaterialTheme.typography.titleMedium)
+            Spacer(modifier = Modifier.height(8.dp))
+
+            if (!state.hasPermissions) {
+                Text("Missing READ_STEPS permission.", color = MaterialTheme.colorScheme.error)
+                return@Column
+            }
+
+            if (state.isLoadingSteps) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                return@Column
+            }
+
+            val steps = state.dailySteps
+            if (steps.isEmpty()) {
+                Text("No data available.")
+                return@Column
+            }
+
+            val hasAnyData = steps.any { it.totalSteps != null && it.totalSteps > 0 }
+            if (!hasAnyData && steps.all { it.error == null }) {
+                Text("No Garmin step data detected", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            Column(modifier = Modifier.fillMaxWidth().heightIn(max = 300.dp)) {
+                LazyColumn {
+                    items(steps) { step ->
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .clickable { onToggleExpanded(step.date) }
+                                .padding(vertical = 4.dp)
+                        ) {
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween
+                            ) {
+                                Text(step.date.toString(), style = MaterialTheme.typography.bodyMedium)
+                                if (step.error != null) {
+                                    Text("Error", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodyMedium)
+                                } else {
+                                    Text(step.totalSteps?.toString() ?: "0", style = MaterialTheme.typography.bodyMedium)
+                                }
+                            }
+                            if (step.isExpanded) {
+                                Spacer(modifier = Modifier.height(4.dp))
+                                Column(modifier = Modifier.padding(start = 16.dp)) {
+                                    if (step.error != null) {
+                                        Text("Error: ${step.error}", color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+                                    }
+                                    Text("Start: ${step.startInstant}", style = MaterialTheme.typography.bodySmall)
+                                    Text("End:   ${step.endInstant}", style = MaterialTheme.typography.bodySmall)
+                                    Text("Raw Aggregate Value: ${step.totalSteps}", style = MaterialTheme.typography.bodySmall)
+                                    Text("Filter: com.garmin.android.apps.connectmobile", style = MaterialTheme.typography.bodySmall)
+                                }
+                            }
+                            HorizontalDivider(modifier = Modifier.padding(top = 4.dp))
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/chrislentner/coach/ui/HealthConnectDebugViewModel.kt
+++ b/app/src/main/java/com/chrislentner/coach/ui/HealthConnectDebugViewModel.kt
@@ -15,11 +15,22 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import java.time.Instant
+import java.time.LocalDate
+import java.time.ZoneId
 import java.time.temporal.ChronoUnit
 import com.chrislentner.coach.health.HealthConnectSyncRoutine
 import com.chrislentner.coach.database.AppDatabase
 import com.chrislentner.coach.database.WorkoutRepository
 import com.chrislentner.coach.database.UserSettingsRepository
+
+data class DailyStepModel(
+    val date: LocalDate,
+    val totalSteps: Long?,
+    val error: String?,
+    val startInstant: Instant,
+    val endInstant: Instant,
+    val isExpanded: Boolean = false
+)
 
 data class HealthConnectState(
     val isAvailable: Boolean = false,
@@ -29,7 +40,9 @@ data class HealthConnectState(
     val error: String? = null,
     val maxHrInput: String = "180", // Default input as string for text field
     val syncLog: String = "",
-    val isSyncing: Boolean = false
+    val isSyncing: Boolean = false,
+    val dailySteps: List<DailyStepModel> = emptyList(),
+    val isLoadingSteps: Boolean = false
 )
 
 data class SessionDebugModel(
@@ -76,7 +89,60 @@ class HealthConnectDebugViewModel(application: Application) : AndroidViewModel(a
 
             if (isAvail && hasPerms) {
                 loadSessions()
+                loadDailySteps()
             }
+        }
+    }
+
+    private fun loadDailySteps() {
+        val context = getApplication<Application>()
+        viewModelScope.launch {
+            _state.update { it.copy(isLoadingSteps = true) }
+            val client = HealthConnectManager.getClient(context)
+            val zoneId = ZoneId.systemDefault()
+            val today = LocalDate.now(zoneId)
+
+            val stepsList = mutableListOf<DailyStepModel>()
+
+            for (i in 0..29) {
+                val d = today.minusDays(i.toLong())
+                val start = d.atStartOfDay(zoneId).toInstant()
+                val end = d.plusDays(1).atStartOfDay(zoneId).toInstant()
+
+                try {
+                    val total = HealthConnectManager.readDailyGarminSteps(client, start, end)
+                    stepsList.add(
+                        DailyStepModel(
+                            date = d,
+                            totalSteps = total,
+                            error = null,
+                            startInstant = start,
+                            endInstant = end
+                        )
+                    )
+                } catch (e: Exception) {
+                    stepsList.add(
+                        DailyStepModel(
+                            date = d,
+                            totalSteps = null,
+                            error = e.message ?: "Unknown error",
+                            startInstant = start,
+                            endInstant = end
+                        )
+                    )
+                }
+            }
+
+            _state.update { it.copy(isLoadingSteps = false, dailySteps = stepsList) }
+        }
+    }
+
+    fun toggleStepExpanded(date: LocalDate) {
+        _state.update { currentState ->
+            val updatedSteps = currentState.dailySteps.map {
+                if (it.date == date) it.copy(isExpanded = !it.isExpanded) else it
+            }
+            currentState.copy(dailySteps = updatedSteps)
         }
     }
 


### PR DESCRIPTION
Added a feature to the Health Connect Debug Screen to display the last 30 days of daily step counts specifically from Garmin. This fetches aggregate data using the `StepsRecord.COUNT_TOTAL` metric and a data origin filter for `com.garmin.android.apps.connectmobile`, explicitly avoiding raw `StepsRecord` reads. It handles the new `READ_STEPS` permission flow and includes an expandable UI for diagnostic details per day.

---
*PR created automatically by Jules for task [17953581308038338337](https://jules.google.com/task/17953581308038338337) started by @clentner*